### PR TITLE
Fix for forcing icons inside buttons to be always white, no matter what

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,45 +5,50 @@
  * It contains typing information for all components that exist in this project.
  */
 
-import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { ButtonType } from "./components/button/button";
-import { IconType } from "./components/icon/icon";
+
+import { HTMLStencilElement, JSXBase } from '@stencil/core/internal';
+import {
+  ButtonType,
+} from './components/button/button';
+import {
+  IconType,
+} from './components/icon/icon';
 
 export namespace Components {
   interface GxgButton {
     /**
-     * The state of the button. Whether is disabled or not. Possible values: false, true
-     */
-    disabled: boolean;
+    * The state of the button. Whether is disabled or not. Possible values: false, true
+    */
+    'disabled': boolean;
     /**
-     * The kind of button Possible values: primary-text-only, primary-text-icon, primary-icon-only, secondary-text-only, secondary-icon-only, outlined
-     */
-    type: ButtonType;
+    * The kind of button Possible values: primary-text-only, primary-text-icon, primary-icon-only, secondary-text-only, secondary-icon-only, outlined
+    */
+    'type': ButtonType;
   }
   interface GxgIcon {
     /**
-     * The color of the icon.
-     */
-    color: "onbackground" | "negative" | "error" | "success" | "warning";
+    * The color of the icon.
+    */
+    'color': "onbackground" | "negative" | "error" | "success" | "warning";
     /**
-     * If enabled, the icon will be loaded lazily when it's visible in the viewport.
-     */
-    lazy: boolean;
+    * If enabled, the icon will be loaded lazily when it's visible in the viewport.
+    */
+    'lazy': boolean;
     /**
-     * The size of the icon. Possible values: regular, small.
-     */
-    size: "regular" | "small";
+    * The size of the icon. Possible values: regular, small.
+    */
+    'size': "regular" | "small";
     /**
-     * The type of icon. Possible values: each of the icons in /assets. The value is always the name of the svg file without the "gxg-icon-" prefix. Example: the value for the "gxg-icon-add.svg" file is "add".
-     */
-    type: IconType;
+    * The type of icon. Possible values: each of the icons in /assets. The value is always the name of the svg file without the "gxg-icon-" prefix. Example: the value for the "gxg-icon-add.svg" file is "add".
+    */
+    'type': IconType;
   }
 }
 
 declare global {
-  interface HTMLGxgButtonElement
-    extends Components.GxgButton,
-      HTMLStencilElement {}
+
+
+  interface HTMLGxgButtonElement extends Components.GxgButton, HTMLStencilElement {}
   var HTMLGxgButtonElement: {
     prototype: HTMLGxgButtonElement;
     new (): HTMLGxgButtonElement;
@@ -55,55 +60,57 @@ declare global {
     new (): HTMLGxgIconElement;
   };
   interface HTMLElementTagNameMap {
-    "gxg-button": HTMLGxgButtonElement;
-    "gxg-icon": HTMLGxgIconElement;
+    'gxg-button': HTMLGxgButtonElement;
+    'gxg-icon': HTMLGxgIconElement;
   }
 }
 
 declare namespace LocalJSX {
   interface GxgButton {
     /**
-     * The state of the button. Whether is disabled or not. Possible values: false, true
-     */
-    disabled?: boolean;
+    * The state of the button. Whether is disabled or not. Possible values: false, true
+    */
+    'disabled'?: boolean;
     /**
-     * The kind of button Possible values: primary-text-only, primary-text-icon, primary-icon-only, secondary-text-only, secondary-icon-only, outlined
-     */
-    type?: ButtonType;
+    * The kind of button Possible values: primary-text-only, primary-text-icon, primary-icon-only, secondary-text-only, secondary-icon-only, outlined
+    */
+    'type'?: ButtonType;
   }
   interface GxgIcon {
     /**
-     * The color of the icon.
-     */
-    color?: "onbackground" | "negative" | "error" | "success" | "warning";
+    * The color of the icon.
+    */
+    'color'?: "onbackground" | "negative" | "error" | "success" | "warning";
     /**
-     * If enabled, the icon will be loaded lazily when it's visible in the viewport.
-     */
-    lazy?: boolean;
+    * If enabled, the icon will be loaded lazily when it's visible in the viewport.
+    */
+    'lazy'?: boolean;
     /**
-     * The size of the icon. Possible values: regular, small.
-     */
-    size?: "regular" | "small";
+    * The size of the icon. Possible values: regular, small.
+    */
+    'size'?: "regular" | "small";
     /**
-     * The type of icon. Possible values: each of the icons in /assets. The value is always the name of the svg file without the "gxg-icon-" prefix. Example: the value for the "gxg-icon-add.svg" file is "add".
-     */
-    type?: IconType;
+    * The type of icon. Possible values: each of the icons in /assets. The value is always the name of the svg file without the "gxg-icon-" prefix. Example: the value for the "gxg-icon-add.svg" file is "add".
+    */
+    'type'?: IconType;
   }
 
   interface IntrinsicElements {
-    "gxg-button": GxgButton;
-    "gxg-icon": GxgIcon;
+    'gxg-button': GxgButton;
+    'gxg-icon': GxgIcon;
   }
 }
 
 export { LocalJSX as JSX };
 
+
 declare module "@stencil/core" {
   export namespace JSX {
     interface IntrinsicElements {
-      "gxg-button": LocalJSX.GxgButton &
-        JSXBase.HTMLAttributes<HTMLGxgButtonElement>;
-      "gxg-icon": LocalJSX.GxgIcon & JSXBase.HTMLAttributes<HTMLGxgIconElement>;
+      'gxg-button': LocalJSX.GxgButton & JSXBase.HTMLAttributes<HTMLGxgButtonElement>;
+      'gxg-icon': LocalJSX.GxgIcon & JSXBase.HTMLAttributes<HTMLGxgIconElement>;
     }
   }
 }
+
+

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -9,9 +9,8 @@
   display: inline-block;
 }
 :host(.button) .button-native {
-  --svg-icon-native-flex-value-small: var(
-    --svg-icon-native-flex-value
-  ); // Force Icon size inside button to always be regular size.
+  // Force Icon size inside button to always be regular size.
+  --svg-icon-native-flex-value-small: var(--svg-icon-native-flex-value);
 
   @include gxg-label;
   background: var(--color-primary-enabled);
@@ -62,6 +61,24 @@
   ::slotted([slot="icon"]) {
     opacity: var(--icon-hover-opacity);
   }
+}
+
+/*********************************************************
+PRIMARY (GENERAL RULES FOR EVERY TYPE OF 'PRIMARY BUTTON')
+*********************************************************/
+:host(.button--primary) .button-native {
+  // Icon color fix: Force Icon color inside "primary button" to be always "--color-on-primary".
+  --color-warning-dark: var(--color-on-primary);
+  --color-error-dark: var(--color-on-primary);
+  --color-success-dark: var(--color-on-primary);
+  --color-on-background: var(--color-on-primary);
+}
+:host(.button--primary.button--disabled) .button-native {
+  // Icon color fix: Force Icon color inside "primary button disabled" to be always "--color-on-disabled".
+  --color-warning-dark: var(--color-on-disabled);
+  --color-error-dark: var(--color-on-disabled);
+  --color-success-dark: var(--color-on-disabled);
+  --color-on-background: var(--color-on-disabled);
 }
 
 /*********************************
@@ -134,6 +151,24 @@ PRIMARY 'TEXT + ICON' BUTTON TYPE
   ::slotted([slot="icon"]) {
     --icon-color: #{$gxg-label--negative-disabled-color};
   }
+}
+
+/*********************************************************
+SECONDARY (GENERAL RULES FOR EVERY TYPE OF 'SECONDARY BUTTON')
+*********************************************************/
+:host(.button--secondary) .button-native {
+  // Icon color fix: Force Icon color inside "secondary button" to be always "--color-primary-enabled".
+  --color-warning-dark: var(--color-primary-enabled);
+  --color-error-dark: var(--color-primary-enabled);
+  --color-success-dark: var(--color-primary-enabled);
+  --color-on-background: var(--color-primary-enabled);
+}
+:host(.button--secondary.button-disabled) .button-native {
+  // Icon color fix: Force Icon color inside "secondary button disabled" to be always "--color-primary-disable".
+  --color-warning-dark: var(--color-primary-disabled);
+  --color-error-dark: var(--color-primary-disabled);
+  --color-success-dark: var(--color-primary-disabled);
+  --color-on-background: var(--color-primary-disabled);
 }
 
 /*********************************

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -23,13 +23,19 @@ export class Button {
       <Host
         class={{
           button: true,
-          "button--primary-text-only": this.type === "primary-text-only",
-          "button--primary-text-icon": this.type === "primary-text-icon",
-          "button--primary-icon-only": this.type === "primary-icon-only",
-          "button--secondary-text-only": this.type === "secondary-text-only",
-          "button--secondary-text-icon": this.type === "secondary-text-icon",
-          "button--secondary-icon-only": this.type === "secondary-icon-only",
-          "button--icon-only button--icon-only--secondary":
+          "button--primary button--primary-text-only":
+            this.type === "primary-text-only",
+          "button--primary button--primary-text-icon":
+            this.type === "primary-text-icon",
+          "button--primary button--primary-icon-only":
+            this.type === "primary-icon-only",
+          "button--secondary button--secondary-text-only":
+            this.type === "secondary-text-only",
+          "button--secondary button--secondary-text-icon":
+            this.type === "secondary-text-icon",
+          "button--secondary button--secondary-icon-only":
+            this.type === "secondary-icon-only",
+          "button--secondary button--icon-only button--icon-only--secondary":
             this.type === "icon-only-secondary",
           "button--outlined": this.type === "outlined",
           "button--disabled": this.disabled === true

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -13,6 +13,11 @@ import { getSvgContent, iconContent } from "./requests";
 const DEFAULT_COLOR = "onbackground";
 
 const COLOR_MAPPINGS = {
+  /*NOTE: If you add, or remove colors from this mapping, remember to update the fixes on /components/button/button.scss. Search for : "Icon color fix" 
+  These fixes force the icon color inside the button to be always the color it should be for a particular button.
+  For example, all icons inside a "primary" button type should always be white, even if the user set the color for the icon as "warning" which 
+  should be orange.*/
+
   onbackground: "color-on-background",
   negative: "color-on-primary",
   error: "color-error-dark",

--- a/src/index.html
+++ b/src/index.html
@@ -175,19 +175,22 @@
     ></gxg-button>
     <br />
     <gxg-button type="primary-text-icon" disabled
-      ><gxg-icon slot="icon" type="add"></gxg-icon>Primary Text Icon</gxg-button
+      ><gxg-icon slot="icon" type="add" color="warning"></gxg-icon>Primary Text
+      Icon</gxg-button
     >
     <br />
 
     <p>Primary Icon Only</p>
     <!--PRIMARY ICON ONLY-->
     <gxg-button type="primary-icon-only"
-      ><gxg-icon slot="icon" type="add" size="small"></gxg-icon
+      ><gxg-icon slot="icon" type="add" size="small" color="warning"></gxg-icon
     ></gxg-button>
 
     <gxg-button type="primary-icon-only" disabled
-      ><gxg-icon slot="icon" type="add"></gxg-icon></gxg-button
+      ><gxg-icon slot="icon" type="add" color="warning"></gxg-icon></gxg-button
     ><br />
+
+    "onbackground" | "negative" | "error" | "success" | "warning";
 
     <p>Secondary Text Only</p>
     <!--SECONDARY TEXT ONLY-->


### PR DESCRIPTION
Hay que ver si conviene hacer esto, porque requiere mantenimiento, en el caso de que se agreguen nuevos colores para los iconos, o en el caso de que decidan quitar algunos. Por otro lado, hay que ver cómo mantener también el color del ícono en los diferentes estados : hover, active, focus, para el botón "secondary". En primary no es necesario, porque siempre es blanco en los diferentes estados.
Te lo muestro en mi compu cuando puedas.