### PR TITLE
Using type-only export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1665,6 +1665,13 @@
         "react-syntax-highlighter": "^11.0.2",
         "regenerator-runtime": "^0.13.3",
         "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+        }
       }
     },
     "@storybook/addon-viewport": {
@@ -2076,6 +2083,13 @@
         "prettier": "^1.16.4",
         "prop-types": "^15.7.2",
         "regenerator-runtime": "^0.13.3"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+        }
       }
     },
     "@storybook/theming": {
@@ -11653,9 +11667,10 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest-cli": "24.9.0",
     "lint-staged": "^9.4.2",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.18.2",
+    "prettier": "^2.2.1",
     "puppeteer": "1.19.0",
     "storybook-addon-themes": "^5.2.0",
     "storybook-dark-mode": "^0.1.9",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './components';
+export type { Components, JSX } from "./components";


### PR DESCRIPTION
Changed the way we export the generated components, by using type-only exports ([introduced by TypeScript 3.8](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html)). 
The prettier dependency was updated to the latest version to support type-only import/export syntax.