### PR TITLE
fix list-box selectionChanged event emit

### DIFF
--- a/src/components/list-box/list-box.tsx
+++ b/src/components/list-box/list-box.tsx
@@ -200,7 +200,6 @@ export class GxgListBox implements FormComponent {
 
   componentDidLoad(): void {
     this.setInitialActive();
-    this.emitInitialSelectedItems();
   }
 
   initialSetup = (): void => {
@@ -256,12 +255,17 @@ export class GxgListBox implements FormComponent {
     const firstSelectedItem = this.getFirstSelectedItem();
     if (firstSelectedItem) {
       this.setActiveItem(firstSelectedItem);
+      this.selectedItems = [
+        {
+          active: firstSelectedItem.active,
+          selected: firstSelectedItem.selected,
+          checked: firstSelectedItem.checked,
+          index: firstSelectedItem.index,
+          value: firstSelectedItem.value || firstSelectedItem.textContent
+        }
+      ];
     }
   };
-
-  private emitInitialSelectedItems() {
-    this.updateSelectedItems();
-  }
 
   @Listen("itemLoaded")
   itemLoadedHandler(): void {
@@ -288,7 +292,7 @@ export class GxgListBox implements FormComponent {
       }
     } else {
       /*multiple-selection allowed*/
-      if (shiftKey || !ctrlKey) {
+      if (shiftKey || (!cmdKey && !cmdKey)) {
         this.clearHighlightedItems();
         this.clearSelectedItems();
       }
@@ -307,7 +311,7 @@ export class GxgListBox implements FormComponent {
           fromIndex = 0;
         }
         this.selectMultipleItems(fromIndex, toIndex);
-      } else if (ctrlKey) {
+      } else if (ctrlKey || cmdKey) {
         if (
           !this.allowsEmpty &&
           this.selectedItemsLength() === 1 &&

--- a/src/components/shortcuts/shortcuts.tsx
+++ b/src/components/shortcuts/shortcuts.tsx
@@ -3,7 +3,7 @@ import { Component, Host, h, Prop, State } from "@stencil/core";
 @Component({
   tag: "gxg-shortcuts",
   styleUrl: "shortcuts.scss",
-  shadow: false,
+  shadow: false
 })
 export class GxgShortcuts {
   /**
@@ -24,7 +24,6 @@ export class GxgShortcuts {
   }
 
   render() {
-    console.log("render");
     return (
       <Host>
         <ch-shortcuts

--- a/src/components/test/test.tsx
+++ b/src/components/test/test.tsx
@@ -7,10 +7,6 @@ import { Component, h, Element } from "@stencil/core";
 export class GxgTest {
   @Element() el: HTMLElement;
 
-  private sendClickHandler = () => {
-    console.log("clicked");
-  };
-
   render() {
     return [
       <div class="container">
@@ -53,7 +49,6 @@ export class GxgTest {
               id="enviar"
               data-shortcut="Enter"
               data-shortcut-action="click"
-              onClick={this.sendClickHandler}
             >
               Enviar
             </button>

--- a/src/pages/tests/list-box-test-selection-changed.html
+++ b/src/pages/tests/list-box-test-selection-changed.html
@@ -14,7 +14,6 @@
   </head>
   <body>
     <gxg-list-box
-      single-selection
       id="list-box-errors"
       the-title="listbox single-selection"
       height="100%"
@@ -48,16 +47,24 @@
         >9.Structured Data Type</gxg-list-box-item
       >
     </gxg-list-box>
+    <br />
+    <button id="get-selected-btn">get selected</button>
     <script>
       const listBox = document.querySelector("gxg-list-box");
-      listBox.addEventListener("selectionChanged", (e) => {
-        console.table("selectionChanged", e.detail.items);
-        // if (e.detail.items.length > 0) {
-        // }
+      listBox.addEventListener("selectionChanged", e => {
+        console.log(`selectionChanged: `, e.detail);
       });
-      listBox.addEventListener("checkedChanged", (e) => {
+      listBox.addEventListener("checkedChanged", e => {
         console.table("checkedChanged", e.detail);
       });
+      const getSelectedBtn = document.getElementById("get-selected-btn");
+      if (getSelectedBtn) {
+        getSelectedBtn.addEventListener("click", () => {
+          listBox.getSelectedItems().then(selectedItems => {
+            console.log(`selectedItems: `, selectedItems);
+          });
+        });
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
On first load, emit this event only if the item was selected by the list-box, and not the user.