### PR TITLE
Bump chameleon-controls-library from 5.0.0-beta.7 to 5.0.0-beta.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.116",
       "license": "MIT",
       "dependencies": {
-        "@genexus/chameleon-controls-library": "~5.0.0-beta.7",
+        "@genexus/chameleon-controls-library": "~5.0.0-beta.10",
         "@simonwep/pickr": "^1.7.4",
         "@stencil/store": "^1.4.1",
         "@storybook/addon-a11y": "^6.1.21",
@@ -2294,9 +2294,9 @@
       }
     },
     "node_modules/@genexus/chameleon-controls-library": {
-      "version": "5.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@genexus/chameleon-controls-library/-/chameleon-controls-library-5.0.0-beta.7.tgz",
-      "integrity": "sha512-TTLlai371CKy7Q4t+xYO4r0GCaGiPZmNBCM/nLcJkDASaxVgVYkp4j4Mw0tHbmvV/UWtt8K1exqdH5TWJduLhQ==",
+      "version": "5.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@genexus/chameleon-controls-library/-/chameleon-controls-library-5.0.0-beta.10.tgz",
+      "integrity": "sha512-i7hewaB1c1I82OOQ3LxIbbfqW0e9ElDWpdN+Abqa73UV9QnG/vOPXjWO8ZSn4n8BWi8zRkA4A+bSuW7eGylSig==",
       "dependencies": {
         "@genexus/markdown-parser": "~0.1.1",
         "html5-qrcode": "^2.3.8",
@@ -28335,9 +28335,9 @@
       "dev": true
     },
     "@genexus/chameleon-controls-library": {
-      "version": "5.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@genexus/chameleon-controls-library/-/chameleon-controls-library-5.0.0-beta.7.tgz",
-      "integrity": "sha512-TTLlai371CKy7Q4t+xYO4r0GCaGiPZmNBCM/nLcJkDASaxVgVYkp4j4Mw0tHbmvV/UWtt8K1exqdH5TWJduLhQ==",
+      "version": "5.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@genexus/chameleon-controls-library/-/chameleon-controls-library-5.0.0-beta.10.tgz",
+      "integrity": "sha512-i7hewaB1c1I82OOQ3LxIbbfqW0e9ElDWpdN+Abqa73UV9QnG/vOPXjWO8ZSn4n8BWi8zRkA4A+bSuW7eGylSig==",
       "requires": {
         "@genexus/markdown-parser": "~0.1.1",
         "html5-qrcode": "^2.3.8",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@genexus/chameleon-controls-library": "~5.0.0-beta.7",
+    "@genexus/chameleon-controls-library": "~5.0.0-beta.10",
     "@simonwep/pickr": "^1.7.4",
     "@stencil/store": "^1.4.1",
     "@storybook/addon-a11y": "^6.1.21",


### PR DESCRIPTION
Related PRs:
- https://github.com/genexuslabs/chameleon-controls-library/pull/251

- https://github.com/genexuslabs/chameleon-controls-library/pull/252
- https://github.com/genexuslabs/chameleon-controls-library/pull/253