### PR TITLE
Remove `JSX.Element` by replacing with `any`

### DIFF
--- a/src/common/form.tsx
+++ b/src/common/form.tsx
@@ -8,13 +8,13 @@ import { Color } from "../components/icon/icon";
 //   validationMessage: string | undefined;
 // }
 
-function requiredLabel(component): JSX.Element {
+function requiredLabel(component): any {
   if (component.required) {
     return <span class="required">*</span>;
   }
 }
 
-function formMessage(children?: JSX.Element[]): JSX.Element {
+function formMessage(children?: any[]): any {
   /* The following snipet of jsx is intended to be inserted at the end of every form-x component.
   The purpose of this jsx snippet is to show error or warning messages,
   inserted on the "message" slot with a gxg-form-message component
@@ -40,7 +40,7 @@ function formHandleValidation(
   }
 }
 
-function formMessageLogic(comp: FormComponent): JSX.Element {
+function formMessageLogic(comp: FormComponent): any {
   {
     return comp.informationMessage ||
       (!comp.disabled &&
@@ -69,7 +69,7 @@ function formMessageLogic(comp: FormComponent): JSX.Element {
 export function formTooltipLogic(
   comp: FormComponent,
   hideTooltip: boolean
-): JSX.Element {
+): any {
   {
     const show =
       comp.validationStatus !== "indeterminate" &&

--- a/src/components/container/container.tsx
+++ b/src/components/container/container.tsx
@@ -3,7 +3,7 @@ import { Component, Host, h, Prop, Element, State } from "@stencil/core";
 @Component({
   tag: "gxg-container",
   styleUrl: "container.scss",
-  shadow: true,
+  shadow: true
 })
 export class GxgContainer {
   /*
@@ -200,7 +200,7 @@ https://stenciljs.com/docs/style-guide#code-organization
       heading: true,
       "heading--no-border": this.noHeadingBorder || this.hasOnlyHeading,
       [`heading--justify-${this.headingJustify}`]: true,
-      ["heading--no-padding"]: this.noHeadingPadding,
+      ["heading--no-padding"]: this.noHeadingPadding
     };
   };
 
@@ -208,11 +208,11 @@ https://stenciljs.com/docs/style-guide#code-organization
     return {
       content: true,
       "content--no-padding": this.noContentPadding,
-      "content--no-gap": this.noContentGap,
+      "content--no-gap": this.noContentGap
     };
   };
 
-  private footer = (): JSX.Element | null => {
+  private footer = (): any | null => {
     return this.hasFooterSlot ? (
       <footer
         class={{
@@ -223,7 +223,7 @@ https://stenciljs.com/docs/style-guide#code-organization
             !this.hasSlottedContent,
           [`footer--justify-${this.footerJustify}`]: true,
           [`footer--justify-${this.footerJustify}`]: true,
-          ["footer--no-padding"]: this.noFooterPadding,
+          ["footer--no-padding"]: this.noFooterPadding
         }}
       >
         <slot name="footer"></slot>
@@ -252,7 +252,7 @@ https://stenciljs.com/docs/style-guide#code-organization
             </div>
           ) : null}
         </fieldset>,
-        this.footer(),
+        this.footer()
       ];
     } else {
       result = [
@@ -266,7 +266,7 @@ https://stenciljs.com/docs/style-guide#code-organization
             <slot></slot>
           </div>
         ) : null,
-        this.footer(),
+        this.footer()
       ];
     }
 
@@ -279,7 +279,7 @@ https://stenciljs.com/docs/style-guide#code-organization
           "gxg-container--display-border-top": this.displayBorderTop,
           "gxg-container--display-border-end": this.displayBorderEnd,
           "gxg-container--display-border-bottom": this.displayBorderBottom,
-          "gxg-container--display-border-start": this.displayBorderStart,
+          "gxg-container--display-border-start": this.displayBorderStart
         }}
       >
         {result}


### PR DESCRIPTION
### Changes in this PR:

- `JSX.Element` type has been replaced for `any` in order to avoid using `@types/react` with StenciJS.